### PR TITLE
New Module Support

### DIFF
--- a/abyssal_modules/management/commands/_abyssal_primitive.py
+++ b/abyssal_modules/management/commands/_abyssal_primitive.py
@@ -17,6 +17,13 @@ RELEVANT_ATTRIBUTES = {
     'damage_mod_bcs': [(50, False), (213, True), (204, True), (1255, True)],
     'damage_control': [(50, False), (974, False), (975, False), (976, False), (977, False)],
     'assault_damage_control': [(50, False), (73, True), (974, False), (975, False), (976, False), (977, False)],
+    'drone_damage_amplifier': [(50, False), (1255, True)],
+    'mutated_light_drone': [(64, True), (160, True), (37, True), (263, True), (9, True), (54, True), (265, True), (158, True)],
+    'mutated_heavy_drone': [(64, True), (160, True), (37, True), (263, True), (9, True), (54, True), (265, True), (158, True)],
+    'mutated_sentry_drone': [(64, True), (160, True), (263, True), (9, True), (54, True), (265, True), (158, True)],
+    'mutated_medium_drone': [(64, True), (160, True), (37, True), (263, True), (9, True), (54, True), (265, True), (158, True)],
+    'abyssal_fighter_support_unit': [(2336, True), (2337, True), (2338, True), (50, False), (30, False), (2335, True)],
+    'abyssal_siege_module': [(2307, True), (2306, True), (2347, True), (2346, False), (30, False)],
 }
 
 ITEMS = [
@@ -283,6 +290,108 @@ ITEMS = [
         "normal_id": 47257,
         "name": "Abyssal Assault Damage Control",
         "relevant_attributes": RELEVANT_ATTRIBUTES['assault_damage_control'],
+    },
+    {
+        "abyssal_id": 60482,
+        "normal_id": 4393,
+        "name": "Mutated Drone Damage Amplifier",
+        "relevant_attributes": RELEVANT_ATTRIBUTES['drone_damage_amplifier'],
+    },
+    {
+        "abyssal_id": 60478,
+        "normal_id": 2203,
+        "name": 'Mutated Light Drone',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['mutated_light_drone'],
+    },
+    {
+        "abyssal_id": 60480,
+        "normal_id": 2444,
+        "name": 'Mutated Heavy Drone',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['mutated_heavy_drone'],
+    },
+    {
+        "abyssal_id": 60481,
+        "normal_id": 23561,
+        "name": 'Mutated Sentry Drone',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['mutated_sentry_drone'],
+    },
+    {
+        "abyssal_id": 60479,
+        "normal_id": 2183,
+        "name": 'Mutated Medium Drone',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['mutated_medium_drone'],
+    },
+    {
+        "abyssal_id": 60483,
+        "normal_id": 24283,
+        "name": 'Abyssal Fighter Support Unit',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['abyssal_fighter_support_unit'],
+    },
+    {
+        "abyssal_id": 56303,
+        "normal_id": 40750,
+        "name": 'Heavy Abyssal Warp Scrambler',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['warp_scrambler'],
+    },
+    {
+        "abyssal_id": 56304,
+        "normal_id": 40730,
+        "name": 'Heavy Abyssal Warp Disrupter',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['warp_disruptor'],
+    },
+    {
+        "abyssal_id": 56305,
+        "normal_id": 41236,
+        "name": '10000MN Abyssal Afterburner',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['afterburner'],
+    },
+    {
+        "abyssal_id": 56306,
+        "normal_id": 41249,
+        "name": '50000MN Abyssal Microwarpdrive',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['microwarpdrive'],
+    },
+    {
+        "abyssal_id": 56307,
+        "normal_id": 20701,
+        "name": 'Capital Abyssal Armor Repairer',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['armor_repairer'],
+    },
+    {
+        "abyssal_id": 56308,
+        "normal_id": 41503,
+        "name": 'Capital Abyssal Ancillary Armor Repairer',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['ancil_armor_repairer'],
+    },
+    {
+        "abyssal_id": 56309,
+        "normal_id": 20703,
+        "name": 'Capital Abyssal Shield Booster',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['shield_booster'],
+    },
+    {
+        "abyssal_id": 56310,
+        "normal_id": 41504,
+        "name": 'Capital Abyssal Ancillary Shield Booster',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['ancil_shield_booster'],
+    },
+    {
+        "abyssal_id": 56311,
+        "normal_id": 40665,
+        "name": 'Capital Abyssal Energy Nosferatu',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['energy_nosferatu'],
+    },
+    {
+        "abyssal_id": 56312,
+        "normal_id": 40659,
+        "name": 'Capital Abyssal Energy Neutralizer',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['energy_neutralizer'],
+    },
+    {
+        "abyssal_id": 56313,
+        "normal_id": 20280,
+        "name": 'Abyssal Siege Module',
+        "relevant_attributes": RELEVANT_ATTRIBUTES['abyssal_siege_module'],
     },
 ]
 

--- a/abyssal_modules/models/attributes.py
+++ b/abyssal_modules/models/attributes.py
@@ -112,5 +112,5 @@ class TypeAttribute(models.Model):
     def pyfa_display(self):
         return self.attribute_id in {
             1795, 6, 1159, 20, 796, 30, 554, 50, 54, 64, 67, 68, 72, 73, 204,
-            84, 213, 983, 90, 2267, 97, 974, 975, 976, 977
+            84, 213, 983, 90, 2267, 97, 974, 975, 976, 977, 1255
         }

--- a/abyssal_modules/models/modules.py
+++ b/abyssal_modules/models/modules.py
@@ -11,14 +11,14 @@ DERIVED_ATTRIBUTES = {
         'types': [47781, 47785, 47789, 47793, 47836, 47838, 47840],
         'name': 'Shield boost per second',
         'unit_str': 'HP/s',
-        'value': lambda x: x.get_value(68) / x.get_value(10073),
+        'value': lambda x: x.get_value(68) / x.get_value(73),
         'high_is_good': True
     },
     100001: {
         'types': [47769, 47773, 47777, 47842, 47844, 47846],
         'name': 'Armor repair per second',
         'unit_str': 'HP/s',
-        'value': lambda x: x.get_value(84) / x.get_value(10073),
+        'value': lambda x: x.get_value(84) / x.get_value(73),
         'high_is_good': True
     },
     100002: {
@@ -39,14 +39,14 @@ DERIVED_ATTRIBUTES = {
         'types': [49730, 49722, 49726, 49734],
         'name': 'DPS Bonus',
         'unit_str': '%',
-        'value': lambda x: ((x.get_value(64) * 1 / (1 - x.get_value(10204) / 100)) - 1) * 100,
+        'value': lambda x: ((x.get_value(64) * 1 / (1 - x.get_value(204) / 100)) - 1) * 100,
         'high_is_good': True
     },
     100005: {
         'types': [49738],
         'name': 'DPS Bonus',
         'unit_str': '%',
-        'value': lambda x: (((x.get_value(10213) / 100 + 1) / (1 - (x.get_value(10204) / 100))) - 1) * 100,
+        'value': lambda x: (((x.get_value(213) / 100 + 1) / (1 - (x.get_value(204) / 100))) - 1) * 100,
         'high_is_good': True
     },
 }

--- a/abyssal_modules/templatetags/abyssal_types.py
+++ b/abyssal_modules/templatetags/abyssal_types.py
@@ -10,12 +10,14 @@ def get_abyssal_type_list():
         ("Microwarpdrives", [
             ("5MN", 47740),
             ("50MN", 47408),
-            ("500MN", 47745)
+            ("500MN", 47745),
+            ("50000MN", 56306)
         ]),
         ("Afterburners", [
             ("1MN", 47749),
             ("10MN", 47753),
-            ("100MN", 47757)
+            ("100MN", 47757),
+            ("10000MN", 56305)
         ]),
         ("Shield Extenders", [
             ("Small", 47800),
@@ -31,32 +33,38 @@ def get_abyssal_type_list():
             ("Small", 47781),
             ("Medium", 47785),
             ("Large", 47789),
-            ("X-Large", 47793)
+            ("X-Large", 47793),
+            ("Capital", 56309)
         ]),
         ("Armor Repairers", [
             ("Small", 47769),
             ("Medium", 47773),
-            ("Large", 47777)
+            ("Large", 47777),
+            ("Capital", 56307)
         ]),
         ("Ancil. Shield Boosters", [
             ("Medium", 47836),
             ("Large", 47838),
-            ("X-Large", 47840)
+            ("X-Large", 47840),
+            ("Capital", 56310)
         ]),
         ("Ancil. Armor Repairers", [
             ("Small", 47842),
             ("Medium", 47844),
-            ("Large", 47846)
+            ("Large", 47846),
+            ("Capital", 56308)
         ]),
         ("Energy Neutralizers", [
             ("Small", 47824),
             ("Medium", 47828),
-            ("Heavy", 47832)
+            ("Heavy", 47832),
+            ("Capital", 56312)
         ]),
         ("Energy Nosferatus", [
             ("Small", 48419),
             ("Medium", 48423),
-            ("Heavy", 48427)
+            ("Heavy", 48427),
+            ("Capital", 56311)
         ]),
         ("Cap Batteries", [
             ("Small", 48431),
@@ -67,20 +75,39 @@ def get_abyssal_type_list():
             ("Stasis Webifiers", 47702)
         ]),
         ("Warp Scramblers", [
-            ("Warp Scramblers", 47732)
+            ("Warp Scramblers", 47732),
+            ("Heavy Warp Scramblers", 56303)
         ]),
         ("Warp Disruptors", [
-            ("Warp Disruptors", 47736)
+            ("Warp Disruptors", 47736),
+            ("Heavy Warp Disruptors", 56304)
         ]),
         ("Damage Modules", [
             ("Gyrostabilizer", 49730),
             ("Mag. Field Stab.", 49722),
             ("Heat Sink", 49726),
             ("Ballistic Control", 49738),
-            ("Entropic Sink", 49734)
+            ("Entropic Sink", 49734),
+            ("Drone Amp.", 60482)
         ]),
         ("Damage Control", [
             ("Standard", 52227),
             ("Assault", 52230)
+        ]),
+        # I'm not sure if this should be a seperate category.
+        # ("Drone Damage Amplifier", [
+        #     ("Radical", 60482)
+        # ]),
+        ("Fighter Support Unit", [
+            ("Fighter Support Unit", 60483)
+        ]),
+        ("Siege Module", [
+            ("Siege Module", 56313)
+        ]),
+        ("Drones", [
+            ("Light", 60478),
+            ("Medium", 60479),
+            ("Heavy", 60480),
+            ("Sentry", 60481),
         ]),
     ]

--- a/static/js/mutaplasmid.js
+++ b/static/js/mutaplasmid.js
@@ -50,9 +50,7 @@ clipboard.on('success', function (e) {
 });
 
 function display_rating(attr) {
-    if (attr == 1255) {
-        return false;
-    } else if (attr == 105) {
+    if (attr == 105) {
         return false;
     } else {
         return true;


### PR DESCRIPTION
Adding support for new modules.

Note: There is now the potentially unwanted behavior of BCUs with drone damage bonuses now having "ratings"... I can extend the existing rating method to exclude these, while including ratings for drone damage elsewhere. It would require a tad bit more code, and I am uncertain which behavior is desired, so I have not yet implemented this.